### PR TITLE
Spec readme role ats banjax swabber

### DIFF
--- a/roles/ats-banjax-swabber/README.md
+++ b/roles/ats-banjax-swabber/README.md
@@ -8,7 +8,9 @@
   installed as an ATS module, and its source code is not kept;
 - ATS is configured to load and use the banjax module;
 - [swabber](https://github.com/equalitie/swabber) is compiled from source and
-  installed, and the source code is not kept.
+  installed, and the source code is not kept;
+- software packages required for compilation but not for run time are not kept
+  on the system.
 
 ## Input data
 

--- a/roles/ats-banjax-swabber/README.md
+++ b/roles/ats-banjax-swabber/README.md
@@ -1,0 +1,6 @@
+# Role `ats-banjax-swabber`
+
+## State of target system after role execution
+
+## Input data
+

--- a/roles/ats-banjax-swabber/README.md
+++ b/roles/ats-banjax-swabber/README.md
@@ -2,5 +2,13 @@
 
 ## State of target system after role execution
 
+- Apache Traffic Server (ATS) is compiled from source and installed on the
+  system, and the source code is not kept on the system;
+- Banjax is compiled from source and installed as an ATS module, and its source
+  code is not kept;
+- ATS is configured to load and use the banjax module;
+- swabber is compiled from source and installed, and the source code is not
+  kept.
+
 ## Input data
 

--- a/roles/ats-banjax-swabber/README.md
+++ b/roles/ats-banjax-swabber/README.md
@@ -2,15 +2,18 @@
 
 ## State of target system after role execution
 
-- Apache Traffic Server (ATS) is compiled from source and installed on the
-  system, and the source code is not kept on the system;
-- [Banjax](https://github.com/equalitie/banjax) is compiled from source and
-  installed as an ATS module, and its source code is not kept;
+- Apache Traffic Server (ATS) is installed on the target system solely in binary
+  form (the role provides the option to either compile the binaries from source
+  on the target — in which case neither the source code or the build-time
+  dependencies are kept on the target after compilation — or to fetch them in
+  binary form from a location given by input data);
+- [Banjax](https://github.com/equalitie/banjax) is installed as an ATS module
+  and kept on the target only in binary form (as above, the role supports
+  on-target compilation as well as fetching the binary);
 - ATS is configured to load and use the banjax module;
-- [swabber](https://github.com/equalitie/swabber) is compiled from source and
-  installed, and the source code is not kept;
-- software packages required for compilation but not for run time are not kept
-  on the system.
+- [swabber](https://github.com/equalitie/swabber) is installed on the target
+  system solely in binary form (as above, the role supports on-target
+  compilation as well fetching as the binary).
 
 ## Input data
 

--- a/roles/ats-banjax-swabber/README.md
+++ b/roles/ats-banjax-swabber/README.md
@@ -4,11 +4,14 @@
 
 - Apache Traffic Server (ATS) is compiled from source and installed on the
   system, and the source code is not kept on the system;
-- Banjax is compiled from source and installed as an ATS module, and its source
-  code is not kept;
+- [Banjax](https://github.com/equalitie/banjax) is compiled from source and
+  installed as an ATS module, and its source code is not kept;
 - ATS is configured to load and use the banjax module;
-- swabber is compiled from source and installed, and the source code is not
-  kept.
+- [swabber](https://github.com/equalitie/swabber) is compiled from source and
+  installed, and the source code is not kept.
 
 ## Input data
 
+- the version of ATS (default: 7.1.1);
+- the version of Banjax (default: 2.0.0);
+- the version of swabber (default: 1.3.5).

--- a/roles/ats-banjax-swabber/README.md
+++ b/roles/ats-banjax-swabber/README.md
@@ -17,6 +17,11 @@
 
 ## Input data
 
-- the version of ATS (default: 7.1.1);
-- the version of Banjax (default: 2.0.0);
-- the version of swabber (default: 1.3.5).
+- the versions to install of:
+    - ATS (default: 7.1.1);
+    - Banjax (default: 2.0.0);
+    - swabber (default: 1.3.5);
+- for each of ATS, Banjax and swabber, one optional URL to fetch packaged
+  binaries from (default: none);
+- for each of ATS, Banjax and swabber, one optional checksum for each file to
+  download (default: none).


### PR DESCRIPTION
This addresses #5.

I am not entirely sure about the software versions that we should put as default. 7.1.1 is our current in-production most modern version of ATS. The two other ones, I took them looking at the github repositories and using the most recent release version number. We could also specify latest on master branch, or a given commit ID. Proper version numbers seem cleaner to me though, but requires that banjax and swabber are correctly versioned.