### PR TITLE
Hardening role install tasks

### DIFF
--- a/roles/generic-system-hardening/tasks/install.yml
+++ b/roles/generic-system-hardening/tasks/install.yml
@@ -1,0 +1,6 @@
+- name: Add Debian security updates repository
+  apt_repository:
+    repo: 'deb http://security.debian.org/ {{ ansible_distribution_release }}/updates main contrib non-free'
+    state: present
+    update_cache: yes
+

--- a/roles/generic-system-hardening/tasks/install.yml
+++ b/roles/generic-system-hardening/tasks/install.yml
@@ -4,3 +4,7 @@
     state: present
     update_cache: yes
 
+- name: Install sudo
+  apt:
+    pkg: sudo
+    state: installed

--- a/roles/generic-system-hardening/tasks/install.yml
+++ b/roles/generic-system-hardening/tasks/install.yml
@@ -1,3 +1,5 @@
+---
+
 - name: Add Debian security updates repository
   apt_repository:
     repo: 'deb http://security.debian.org/ {{ ansible_distribution_release }}/updates main contrib non-free'

--- a/roles/generic-system-hardening/tasks/main.yml
+++ b/roles/generic-system-hardening/tasks/main.yml
@@ -1,0 +1,2 @@
+- import_tasks: install.yml
+  tags: ["generic-system-hardening", "install", "install_generic-system-hardening"]

--- a/roles/generic-system-hardening/tasks/main.yml
+++ b/roles/generic-system-hardening/tasks/main.yml
@@ -1,2 +1,4 @@
+---
+
 - import_tasks: install.yml
   tags: ["generic-system-hardening", "install", "install_generic-system-hardening"]


### PR DESCRIPTION
A simplistic merge request that addresses a small part of #7. More importantly an attempt at separating tasks with tags, so that at Ansible run-time they can be picked whether they are:

- part of a specifically wanted role (the tag is the name of the role);
- part of the installation process (tag `install`);
- part of either "static configuration" or "dynamic configuration" tasks, but not in this MR as I first want to check whether this approach with `import_tasks` is fine.